### PR TITLE
Fixes prefix and dbxref_id issues

### DIFF
--- a/includes/TripalImporter/GermplasmPopulationImporter.inc
+++ b/includes/TripalImporter/GermplasmPopulationImporter.inc
@@ -102,7 +102,7 @@
 
     // Do allow importer if not configured.
     $configuration = $this->getConfigurationSettings();
-    if ($configuration['verb'] == 0) {
+    if (empty($configuration['verb']) || empty($configuration['db'])) {
       $l = l(t('Configure Importer'), 'admin/tripal/extension/germplasm_population_importer/configure');
       $form['not_configured'] = [
         '#markup' => '<div class="messages error">
@@ -427,7 +427,8 @@
       'verb'    => $arguments['fld_select_relationship_verb'], // Cvterm (Type) Id Numnber.
       'position'  => $arguments['fld_radio_stock_position'],   // EVI or IVE position type.
       'individuals' => $this->arguments['files'][0]['fid'],    // Individuals File Id.
-      'prefix' => $prefix                                      // Default Prefix.
+      'prefix' => $prefix,                                     // Default Prefix.
+      'db' => $configuration['db'],                            // Default Database
     ];
 
     $this->importPopulation($population);
@@ -493,7 +494,7 @@
             // If line has no uniquename by using the prefix system configuration
             // and next sequence id of stock.
             $uniquename = ($val_uniqname == '') 
-              ? $population['prefix'] . ':' . ($last_id + $i) : $val_uniqname;
+              ? $population['prefix'] . ($last_id + $i) : $val_uniqname;
             // Always encode in uppercase form.
             $uniquename = strtoupper($uniquename);
 
@@ -510,6 +511,14 @@
             $type_id = $this->parseTerm($val_type);
             
             // Population individual to insert.
+            // Insert dbxref entry matching the uniquename of the stock, dbxref_id 
+            // generated will be the value for dbxref_id FK in chado.stock table.
+            // This entry will be stored in the default Database name set in configuration.
+            // 1. DBXREF:
+            $dbxref_values = ['db_id' => $population['db'], 'accession' => $uniquename];
+            $dbxref_id = chado_insert_record('dbxref', $dbxref_values);
+            
+            // 2. STOCK:
             $stock = [
               'name'      => $val_name,
               'uniquename'  => $uniquename,
@@ -517,6 +526,10 @@
               'description' => $description,
               'type_id'   => $type_id,
             ];
+
+            if ($dbxref_id) {
+              $stock['dbxref_id'] = $dbxref_values;
+            }
 
             // Save the id of the individual being added 
             // and use it in the relationship below. 
@@ -564,10 +577,13 @@
     $verb_configuration = variable_get('germplasm_population_importer_verb_cv');
     // Prefix configuration.
     $prefix_configuration = variable_get('germplasm_population_importer_default_prefix');
+    // Db configuration.
+    $db_configuration = variable_get('germplasm_population_importer_db');
 
     return [
       'verb' => $verb_configuration, 
-      'prefix' => $prefix_configuration
+      'prefix' => $prefix_configuration,
+      'db' => $db_configuration,
     ];
   }
 

--- a/includes/germplasm_population_importer.config.form.inc
+++ b/includes/germplasm_population_importer.config.form.inc
@@ -126,6 +126,25 @@ function germplasm_population_importer_config_form($form, &$form_state) {
     '#collapsible' => FALSE,
   ];
   
+    # FIELD: Database identifier used in dbxref_id column when inserting stocks
+    // into chado.stock table.
+    $fld_db_options = [];
+    $dbs = tripal_get_db_select_options();
+    $fld_db_options = [0 => '- Select -'] + $dbs;
+
+    // Configuration name, set during install/enable to 0.
+    $config_db = 'germplasm_population_importer_db';
+    // Default/current value of the configuration.
+    $default_db = variable_get($config_db);
+
+    $form['fieldset_importer_configuration'][ $config_db ] = [
+      '#type' => 'select',
+      '#options' => $fld_db_options,
+      '#default_value' => $default_db,
+      '#description' => t('Germplasm Population Importer uses Database for secondary identifier. Set this field to
+        the database name where your germplasm resides.'),
+    ];
+
     # FIELD: Germplasm Population Importer verb controlled vocabulary setting.
     // Create a select option showing all cvs currently available.
     // Set it to default value of the configuration variable.
@@ -155,7 +174,8 @@ function germplasm_population_importer_config_form($form, &$form_state) {
     $form['fieldset_importer_configuration'][ $config_prefix ] = [
       '#type' => 'textfield',
       '#default_value' => $default_prefix,
-      '#description' => t('Use this field value as default germplasm prefix.'),
+      '#description' => t('Use this field value as default germplasm prefix. If special characters are part of your prefix naming scheme, 
+        please include it here (i.e., GERM: or GERM# for GERM:123 or GERM#123).'),
       '#attributes' => [
         'onkeyup' => "this.value = this.value.toUpperCase();"
       ],

--- a/tests/DatabaseSeeders/GermplasmPopulationSeeder.php
+++ b/tests/DatabaseSeeders/GermplasmPopulationSeeder.php
@@ -8,6 +8,10 @@ use \Exception;
 class GermplasmPopulationSeeder extends Seeder {
   public function up() {
     $data = [];
+    
+    // Add a database.
+    $db = chado_insert_record('db', ['name' => 'TestDB', 'description' => 'Test Database']);
+    $data['database'] = $db['db_id'];
 
     // Add cv - stock_relationship.
     // This will be used for relationship verb configuration.

--- a/tests/GermplasmPopulationImportingTest.php
+++ b/tests/GermplasmPopulationImportingTest.php
@@ -135,7 +135,7 @@ class GermplasmPopulationImportingTest extends TripalTestCase {
       // Assert stock inserted name matched.
       $this->assertEquals($germ[0]->name, $val_name, 'Stock inserted name does not match name in file.');
       // Uniquename matches expected uniquename generated using default prefix configuration.
-      $this->assertEquals($germ[0]->uniquename, $configurations['prefix'] . ':' . $germ[0]->stock_id, 
+      $this->assertEquals($germ[0]->uniquename, $configurations['prefix'] . $germ[0]->stock_id, 
         'Stock inserted uniquename is not in the expected value.');
     
       $stocks_inserted[ $germ[0]->stock_id ] = $germ[0]->stock_id;

--- a/uofspb_germplasm.install
+++ b/uofspb_germplasm.install
@@ -89,10 +89,15 @@ function uofspb_germplasm_enable(){
   );
   chado_create_custom_table($table, $schema, TRUE, NULL, FALSE);
 
+  // Relationship verb and Default db set to 0, frontend will notify user
+  // to configure these variables before any upload.
+
   // Create a settings/configuration variable used by
   // Germplasm Population Importer to limit/filter relationship verb
   // field to specific controlled vocabulary.
   variable_set('germplasm_population_importer_verb_cv', 0);
   // Default prefix used in germplasm names.
   variable_set('germplasm_population_importer_default_prefix', 'GERM');
+  // Default db used by chado stock.dbxref_id when inserting germplasm.
+  variable_set('germplasm_population_importer_db', 0);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->
This PR removes auto-insert of special character delimiter as part of the prefix and supplies dbxref information to stocks inserted.

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue # https://github.com/UofS-Pulse-Binfo/uofspb_germplasm/issues/21

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Dependencies
<!-- If this code is dependent upon another module and/or PR, 
       state that here. -->
<!-- Include information about other modules/PRs needed for testing,
        which to enable/merge first, etc. -->

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [ ] I tested on a generic Tripal Site
- [x] I tested on a KnowPulse Clone
- [x] This PR includes automated testing

To test:
1. Pull recent branch prefix-and-dbxref
2. Clear cache
3. Set database configuration variable in configuration page
4. Import stocks
5. See imported stock using Population viewer in configuration page for generated uniquename (With default prefix GERM, uniquenames should exclude any : (colon characters)

Inspect dbxref and database
1. Query stock inserted to include dbxref_id id number
2. Query dbxref table using the dbxref_id in step 1, the accession information should match the uniquename of the stock.
3. Using the db_id in step 2, query chado.db table and db name should match the configured database.

Example below:
![image](https://user-images.githubusercontent.com/15472253/229587824-c53aadf0-cbfa-4b94-a371-c31025d469d5.png)

